### PR TITLE
Fixed issue with getting local group members if membership contains an entry with an orphaned SID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix DNS Zone table not displaying 'Available For Scavenge' and 'Last Scavenge Time' correctly
 - Fix DHCP Infrastructure table not displaying 'Database Logging Enabled' and 'Database Backup Interval' correctly
+- Fix [#31](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.Windows/issues/31)
 
 ## [0.5.4] - 2024-05-16
 

--- a/Src/Private/SharedUtilsFunctions.ps1
+++ b/Src/Private/SharedUtilsFunctions.ps1
@@ -1,7 +1,7 @@
 function ConvertTo-TextYN {
     <#
     .SYNOPSIS
-    Used by As Built Report to convert true or false automatically to Yes or No.
+        Used by As Built Report to convert true or false automatically to Yes or No.
     .DESCRIPTION
 
     .NOTES
@@ -37,7 +37,7 @@ function ConvertTo-TextYN {
 function ConvertTo-FileSizeString {
     <#
     .SYNOPSIS
-    Used by As Built Report to convert bytes automatically to GB or TB based on size.
+        Used by As Built Report to convert bytes automatically to GB or TB based on size.
     .DESCRIPTION
 
     .NOTES
@@ -81,7 +81,7 @@ function ConvertTo-FileSizeString {
 function ConvertTo-EmptyToFiller {
     <#
     .SYNOPSIS
-    Used by As Built Report to convert empty culumns to "--".
+        Used by As Built Report to convert empty culumns to "--".
     .DESCRIPTION
     .NOTES
         Version:        0.5.0
@@ -109,7 +109,7 @@ function ConvertTo-EmptyToFiller {
 function Convert-IpAddressToMaskLength {
     <#
     .SYNOPSIS
-    Used by As Built Report to convert subnet mask to dotted notation.
+        Used by As Built Report to convert subnet mask to dotted notation.
     .DESCRIPTION
 
     .NOTES
@@ -146,7 +146,7 @@ function Convert-IpAddressToMaskLength {
 function ConvertTo-ADObjectName {
     <#
     .SYNOPSIS
-    Used by As Built Report to translate Active Directory DN to Name.
+        Used by As Built Report to translate Active Directory DN to Name.
     .DESCRIPTION
 
     .NOTES
@@ -170,3 +170,358 @@ function ConvertTo-ADObjectName {
     }
     return $ADObject;
 }# end
+
+Function Get-LocalGroupMembership {
+    <#
+    .SYNOPSIS
+        Recursively list all members of a specified Local group.
+
+    .DESCRIPTION
+        Recursively list all members of a specified Local group. This can be run against a local or
+        remote system or systems. Recursion is unlimited unless specified by the -Depth parameter.
+
+        Alias: glgm
+    
+    .NOTES
+        Version:        0.5.4
+        Author:         Boe Prox, Updated by Graham Flynn
+        Changes:        Updated to ouput PrincipalSource and ObjectClass so output is similar to Microsoft's Get-LocalGroupMember for compatibility
+
+    .PARAMETER Computername
+        Local or remote computer/s to perform the query against.
+        Default value is the local system.
+
+    .PARAMETER Group
+        Name of the group to query on a system for all members.
+        Default value is 'Administrators'
+
+    .PARAMETER Depth
+        Limit the recursive depth of a query. 
+        Default value is 2147483647.
+
+    .PARAMETER Throttle
+        Number of concurrently running jobs to run at a time
+        Default value is 10
+
+    .EXAMPLE
+        Get-LocalGroupMembership
+
+        Name              ParentGroup       isGroup     ObjectClass PrincipalSource   Computername Depth
+        ----              -----------       -------     ----        ------------      -----
+        Administrator     Administrators      False     User        Local             DC1              1
+        boe               Administrators      False     User        Domain            DC1              1
+        testuser          Administrators      False     User        Local             DC1              1
+        bob               Administrators      False     User        Domain            DC1              1
+        proxb             Administrators      False     User        Domain            DC1              1
+        Enterprise Admins Administrators      True      Group       Domain            DC1              1
+        Sysops Admins     Enterprise Admins   True      Group       Domain            DC1              2
+        Domain Admins     Enterprise Admins   True      Group       Domain            DC1              2
+        Administrator     Enterprise Admins   False     User        Domain            DC1              2
+        Domain Admins     Administrators      True      Group       Domain            DC1              1
+        proxb             Domain Admins       False     User        Domain            DC1              2
+        Administrator     Domain Admins       False     User        Domain            DC1              2
+        Sysops Admins     Administrators      True      Group       Domain            DC1              1
+        Org Admins        Sysops Admins       True      Group       Domain            DC1              2
+        Enterprise Admins Sysops Admins       True      Group       Domain            DC1              2       
+        
+        Description
+        -----------
+        Gets all of the members of the 'Administrators' group on the local system.        
+        
+    .EXAMPLE
+        Get-LocalGroupMembership -Group 'Administrators' -Depth 1
+        
+        Name              ParentGroup    isGroup    ObjectClass PrincipalSource   Computername Depth
+        ----              -----------    -------    ----        ------------      -----
+        Administrator     Administrators   False    User        Local             DC1              1
+        boe               Administrators   False    User        Domain            DC1              1
+        testuser          Administrators   False    User        Local             DC1              1
+        bob               Administrators   False    User        Domain            DC1              1
+        proxb             Administrators   False    User        Domain            DC1              1
+        Enterprise Admins Administrators   True     Group       Domain            DC1              1
+        Domain Admins     Administrators   True     Group       Domain            DC1              1
+        Sysops Admins     Administrators   True     Group       Domain            DC1              1   
+        
+        Description
+        -----------
+        Gets the members of 'Administrators' with only 1 level of recursion.
+
+    .LINK
+        Original Script: https://github.com/proxb/PowerShell_Scripts/blob/master/Get-LocalGroupMembership.ps1
+        
+    #>
+    [cmdletbinding()]
+    Param (
+        [parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [Alias('CN', '__Server', 'Computer', 'IPAddress')]
+        [string[]]$Computername = $env:COMPUTERNAME,
+        [parameter()]
+        [string]$Group = "Administrators",
+        [parameter()]
+        [int]$Depth = ([int]::MaxValue),
+        [parameter()]
+        [Alias("MaxJobs")]
+        [int]$Throttle = 10
+    )
+    Begin {
+        $PSBoundParameters.GetEnumerator() | ForEach {
+            Write-Verbose $_
+        }
+        #region Extra Configurations
+        Write-Verbose ("Depth: {0}" -f $Depth)
+        #endregion Extra Configurations
+        #Define hash table for Get-RunspaceData function
+        $runspacehash = @{}
+        #Function to perform runspace job cleanup
+        Function Get-RunspaceData {
+            [cmdletbinding()]
+            param(
+                [switch]$Wait
+            )
+            Do {
+                $more = $false         
+                Foreach ($runspace in $runspaces) {
+                    If ($runspace.Runspace.isCompleted) {
+                        $runspace.powershell.EndInvoke($runspace.Runspace)
+                        $runspace.powershell.dispose()
+                        $runspace.Runspace = $null
+                        $runspace.powershell = $null                 
+                    }
+                    ElseIf ($runspace.Runspace -ne $null) {
+                        $more = $true
+                    }
+                }
+                If ($more -AND $PSBoundParameters['Wait']) {
+                    Start-Sleep -Milliseconds 100
+                }   
+                #Clean out unused runspace jobs
+                $temphash = $runspaces.clone()
+                $temphash | Where {
+                    $_.runspace -eq $Null
+                } | ForEach {
+                    Write-Verbose ("Removing {0}" -f $_.computer)
+                    $Runspaces.remove($_)
+                }             
+            } while ($more -AND $PSBoundParameters['Wait'])
+        }
+
+        #region ScriptBlock
+        $scriptBlock = {
+            Param ($Computer, $Group, $Depth, $NetBIOSDomain, $ObjNT, $Translate)            
+            $Script:Depth = $Depth
+            $Script:ObjNT = $ObjNT
+            $Script:Translate = $Translate
+            $Script:NetBIOSDomain = $NetBIOSDomain
+            Function Get-LocalGroupMember {
+                [cmdletbinding()]
+                Param (
+                    [parameter()]
+                    [System.DirectoryServices.DirectoryEntry]$LocalGroup
+                )
+                # Invoke the Members method and convert to an array of member objects.
+                $Members = @($LocalGroup.psbase.Invoke("Members")) | foreach { ([System.DirectoryServices.DirectoryEntry]$_) }
+                $Counter++
+                ForEach ($Member In $Members) {                
+                    Try {
+						
+                        $Name = $Member.InvokeGet("Name")
+                        $Path = $Member.InvokeGet("AdsPath")
+
+                        # Check if this member is a group.
+                        $isGroup = ($Member.InvokeGet("Class") -eq "group")
+
+                        #Remove the domain from the computername to fix the type comparison when supplied with FQDN
+                        IF ($Computer.Contains('.')) {
+                            $Computer = $computer.Substring(0, $computer.IndexOf('.'))
+                        }
+
+                        If (($Path -like "*/$Computer/*")) {
+                            $Type = 'Local'
+                        }
+                        Else { $Type = 'Domain' }
+						
+                        # Add Objectclass to match Get-LocalGroupMember output
+                        if ($isGroup) {
+                            $ObjectClass = 'Group'
+                        }
+                        elseif ($isGroup -eq $false) {
+                            $ObjectClass = 'User'
+                        }
+                        else {
+                            'Unknown'
+                        }
+
+                        New-Object PSObject -Property @{
+                            Computername    = $Computer
+                            Name            = $Name
+                            PrincipalSource = $Type
+                            ParentGroup     = $LocalGroup.Name[0]
+                            isGroup         = $isGroup
+                            ObjectClass     = $ObjectClass
+                            Depth           = $Counter
+                            Group           = $Group
+                        }
+                        If ($isGroup) {
+                            # Check if this group is local or domain.
+                            #$host.ui.WriteVerboseLine("(RS)Checking if Counter: {0} is less than Depth: {1}" -f $Counter, $Depth)
+                            If ($Counter -lt $Depth) {
+                                If ($Type -eq 'Local') {
+                                    If ($Groups[$Name] -notcontains 'Local') {
+                                        $host.ui.WriteVerboseLine(("{0}: Getting local group members" -f $Name))
+                                        $Groups[$Name] += , 'Local'
+                                        # Enumerate members of local group.
+                                        Get-LocalGroupMember $Member
+                                    }
+                                }
+                                Else {
+                                    If ($Groups[$Name] -notcontains 'Domain') {
+                                        $host.ui.WriteVerboseLine(("{0}: Getting domain group members" -f $Name))
+                                        $Groups[$Name] += , 'Domain'
+                                        # Enumerate members of domain group.
+                                        Get-DomainGroupMember $Member $Name $True
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Catch {
+                        $host.ui.WriteWarningLine(("GLGM{0}" -f $_.Exception.Message))
+                    }
+                }
+            }
+
+            Function Get-DomainGroupMember {
+                [cmdletbinding()]
+                Param (
+                    [parameter()]
+                    $DomainGroup, 
+                    [parameter()]
+                    [string]$NTName, 
+                    [parameter()]
+                    [string]$blnNT
+                )
+                Try {
+                    If ($blnNT -eq $True) {
+                        # Convert NetBIOS domain name of group to Distinguished Name.
+                        $objNT.InvokeMember("Set", "InvokeMethod", $Null, $Translate, (3, ("{0}{1}" -f $NetBIOSDomain.Trim(), $NTName)))
+                        $DN = $objNT.InvokeMember("Get", "InvokeMethod", $Null, $Translate, 1)
+                        $ADGroup = [ADSI]"LDAP://$DN"
+                    }
+                    Else {
+                        $DN = $DomainGroup.distinguishedName
+                        $ADGroup = $DomainGroup
+                    }         
+                    $Counter++   
+                    ForEach ($MemberDN In $ADGroup.Member) {
+                        $MemberGroup = [ADSI]("LDAP://{0}" -f ($MemberDN -replace '/', '\/'))
+						
+                        # Add Objectclass to match Get-LocalGroupMember output
+                        if ($MemberGroup.Class -eq "group") {
+                            $ObjectClass = 'Group'
+                        }
+                        else {
+                            $ObjectClass = 'User'
+                        }
+						
+                        New-Object PSObject -Property @{
+                            Computername    = $Computer
+                            Name            = $MemberGroup.name[0]
+                            PrincipalSource = 'Domain'
+                            ParentGroup     = $NTName
+                            isGroup         = ($MemberGroup.Class -eq "group")
+                            ObjectClass     = $ObjectClass
+                            Depth           = $Counter
+                            Group           = $Group
+                        }
+                        # Check if this member is a group.
+                        If ($MemberGroup.Class -eq "group") {              
+                            If ($Counter -lt $Depth) {
+                                If ($Groups[$MemberGroup.name[0]] -notcontains 'Domain') {
+                                    Write-Verbose ("{0}: Getting domain group members" -f $MemberGroup.name[0])
+                                    $Groups[$MemberGroup.name[0]] += , 'Domain'
+                                    # Enumerate members of domain group.
+                                    Get-DomainGroupMember $MemberGroup $MemberGroup.Name[0] $False
+                                }                                                
+                            }
+                        }
+                    }
+                }
+                Catch {
+                    $host.ui.WriteWarningLine(("GDGM{0}" -f $_.Exception.Message))
+                }
+            }
+            #region Get Local Group Members
+            $Script:Groups = @{}
+            $Script:Counter = 0
+            # Bind to the group object with the WinNT provider.
+            $ADSIGroup = [ADSI]"WinNT://$Computer/$Group,group"
+            Write-Verbose ("Checking {0} membership for {1}" -f $Group, $Computer)
+            $Groups[$Group] += , 'Local'
+            Get-LocalGroupMember -LocalGroup $ADSIGroup
+            #endregion Get Local Group Members
+        }
+        #endregion ScriptBlock
+        Write-Verbose ("Checking to see if connected to a domain")
+        Try {
+            $Domain = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+            $Root = $Domain.GetDirectoryEntry()
+            $Base = ($Root.distinguishedName)
+
+            # Use the NameTranslate object.
+            $Script:Translate = New-Object -comObject "NameTranslate"
+            $Script:objNT = $Translate.GetType()
+
+            # Initialize NameTranslate by locating the Global Catalog.
+            $objNT.InvokeMember("Init", "InvokeMethod", $Null, $Translate, (3, $Null))
+
+            # Retrieve NetBIOS name of the current domain.
+            $objNT.InvokeMember("Set", "InvokeMethod", $Null, $Translate, (1, "$Base"))
+            [string]$Script:NetBIOSDomain = $objNT.InvokeMember("Get", "InvokeMethod", $Null, $Translate, 3)  
+        }
+        Catch { Write-Warning ("{0}" -f $_.Exception.Message) }         
+        
+        #region Runspace Creation
+        Write-Verbose ("Creating runspace pool and session states")
+        $sessionstate = [system.management.automation.runspaces.initialsessionstate]::CreateDefault()
+        $runspacepool = [runspacefactory]::CreateRunspacePool(1, $Throttle, $sessionstate, $Host)
+        $runspacepool.Open()  
+        
+        Write-Verbose ("Creating empty collection to hold runspace jobs")
+        $Script:runspaces = New-Object System.Collections.ArrayList        
+        #endregion Runspace Creation
+    }
+
+    Process {
+        ForEach ($Computer in $Computername) {
+            #Create the powershell instance and supply the scriptblock with the other parameters 
+            $powershell = [powershell]::Create().AddScript($scriptBlock).AddArgument($computer).AddArgument($Group).AddArgument($Depth).AddArgument($NetBIOSDomain).AddArgument($ObjNT).AddArgument($Translate)
+           
+            #Add the runspace into the powershell instance
+            $powershell.RunspacePool = $runspacepool
+           
+            #Create a temporary collection for each runspace
+            $temp = "" | Select-Object PowerShell, Runspace, Computer
+            $Temp.Computer = $Computer
+            $temp.PowerShell = $powershell
+           
+            #Save the handle output when calling BeginInvoke() that will be used later to end the runspace
+            $temp.Runspace = $powershell.BeginInvoke()
+            Write-Verbose ("Adding {0} collection" -f $temp.Computer)
+            $runspaces.Add($temp) | Out-Null
+           
+            Write-Verbose ("Checking status of runspace jobs")
+            Get-RunspaceData @runspacehash   
+        }
+    }
+    End {
+        Write-Verbose ("Finish processing the remaining runspace jobs: {0}" -f (@(($runspaces | Where { $_.Runspace -ne $Null }).Count)))
+        $runspacehash.Wait = $true
+        Get-RunspaceData @runspacehash
+    
+        #region Cleanup Runspace
+        Write-Verbose ("Closing the runspace pool")
+        $runspacepool.close()  
+        $runspacepool.Dispose() 
+        #endregion Cleanup Runspace    
+    }
+}

--- a/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
@@ -111,7 +111,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
             if ($InfoLevel.Account -ge 1) {
                 try {
                     # Get the AsBuiltReport.Microsoft.Windows Shared Util Functions path and file
-                    $AsBuiltWinModuleFolder = (Get-InstalledModule -Name "AsBuiltReport.Microsoft.Windows" -AllVersions | Sort-Object Version -Descending | Select-Object -First 1).InstalledLocation
+                    $AsBuiltWinModuleFolder = (Get-Module -ListAvailable -Name "AsBuiltReport.Microsoft.Windows" | Sort-Object Version -Descending | Select-Object -First 1).Path | Split-Path
                     $SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
                     # Dot-source the script from the latest version
                     . $SharedFunctionPath 

--- a/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
@@ -38,7 +38,8 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                 Write-PScriboMessage -Plugin "Module" -IsWarning "Run 'Update-Module -Name AsBuiltReport.Microsoft.Windows -Force' to install the latest version."
             }
         }
-    } Catch {
+    }
+    Catch {
         Write-PScriboMessage -IsWarning $_.Exception.Message
     }
 
@@ -66,7 +67,8 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
             try {
                 $script:TempPssSession = New-PSSession $System -Credential $Credential -Authentication Negotiate -ErrorAction stop
                 $script:TempCimSession = New-CimSession $System -Credential $Credential -Authentication Negotiate -ErrorAction stop
-            } catch {
+            }
+            catch {
                 Write-PScriboMessage -IsWarning  "Unable to connect to $($System)"
                 throw
             }
@@ -100,55 +102,57 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         # Host Service Status
                         Get-AbrWinOSService
                     }
-                } catch {
+                }
+                catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
             #Local Users and Groups
             if ($InfoLevel.Account -ge 1) {
                 try {
-					# Get the AsBuiltReport.Microsoft.Windows Shared Util Functions path and file
-					$AsBuiltWinModuleFolder = (Get-InstalledModule -Name "AsBuiltReport.Microsoft.Windows" -AllVersions | Sort-Object Version -Descending | Select-Object -First 1).InstalledLocation
-					$SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
-					# Dot-source the script from the latest version
-					. $SharedFunctionPath 
-					# Read the Shared Util Function into a variable to pass through to a script block so that remote computers have this script available locally
-					$SharedFunctions = [System.IO.File]::ReadAllText($SharedFunctionPath)
-					# Get Local Users
-		                    	$LocalUsers = Invoke-Command -Session $TempPssSession { Get-LocalUser | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } }
+                    # Get the AsBuiltReport.Microsoft.Windows Shared Util Functions path and file
+                    $AsBuiltWinModuleFolder = (Get-InstalledModule -Name "AsBuiltReport.Microsoft.Windows" -AllVersions | Sort-Object Version -Descending | Select-Object -First 1).InstalledLocation
+                    $SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
+                    # Dot-source the script from the latest version
+                    . $SharedFunctionPath 
+                    # Read the Shared Util Function into a variable to pass through to a script block so that remote computers have this script available locally
+                    $SharedFunctions = [System.IO.File]::ReadAllText($SharedFunctionPath)
+                    # Get Local Users
+                    $LocalUsers = Invoke-Command -Session $TempPssSession { Get-LocalUser | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } }
 					
-					# Get Local Groups and their members
-					$LocalGroups = Invoke-Command -Session $TempPssSession -ScriptBlock {
-						param ($ScriptContent)
+                    # Get Local Groups and their members
+                    $LocalGroups = Invoke-Command -Session $TempPssSession -ScriptBlock {
+                        param ($ScriptContent)
 			
-						# Create and dot-source the script block so the remote computer can use our shared functions
-						. ([scriptblock]::Create($ScriptContent))
+                        # Create and dot-source the script block so the remote computer can use our shared functions
+                        . ([scriptblock]::Create($ScriptContent))
 			
-						$Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } } 
-						Write-Output $Result
-					} -ArgumentList $SharedFunctions	
+                        $Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } } 
+                        Write-Output $Result
+                    } -ArgumentList $SharedFunctions	
 					
-					# Get Local Administrators members
-					$LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
-					# Remove empty or null elements
-					$LocalAdmins = $LocalAdmins | Where-Object { $_ }
+                    # Get Local Administrators members
+                    $LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
+                    # Remove empty or null elements
+                    $LocalAdmins = $LocalAdmins | Where-Object { $_ }
 					
-					Write-Host "Local Admins -----"
-					$LocalAdmins
+                    Write-Host "Local Admins -----"
+                    $LocalAdmins
 
                     if ($LocalUsers -or $LocalGroups -or $LocalAdmins) {
-						Section -Style Heading2 'Local Users and Groups' {
-							Paragraph 'The following section details local configured users and groups'
-							BlankLine
-							#Local Users
-							Get-AbrWinLocalUser
-							#Local Groups
-							Get-AbrWinLocalGroup
-							#Local Administrators
-							Get-AbrWinLocalAdmin
-						}
+                        Section -Style Heading2 'Local Users and Groups' {
+                            Paragraph 'The following section details local configured users and groups'
+                            BlankLine
+                            #Local Users
+                            Get-AbrWinLocalUser
+                            #Local Groups
+                            Get-AbrWinLocalGroup
+                            #Local Administrators
+                            Get-AbrWinLocalAdmin
+                        }
                     }
-                } catch {
+                }
+                catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -173,7 +177,8 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         #Host Network Adapter MTU
                         Get-AbrWinNetAdapterMTU
                     }
-                } catch {
+                }
+                catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -191,7 +196,8 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         #MPIO Setting
                         Get-AbrWinHostStorageMPIO
                     }
-                } catch {
+                }
+                catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -213,13 +219,16 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # Hyper-V VM Information
                                 Get-AbrWinHyperVHostVM
                             }
-                        } else {
+                        }
+                        else {
                             Get-RequiredFeature -Name Hyper-V-PowerShell -OSType $OSType.Value -Service "Hyper-V"
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                } else {
+                }
+                else {
                     Write-PScriboMessage "No HyperV service detected. Disabling HyperV server section"
                 }
             }
@@ -238,20 +247,24 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # IIS Web Site
                                 Get-AbrWinIISWebSite
                             }
-                        } else {
+                        }
+                        else {
                             If ($OSType -eq 'Server' -or $OSType -eq 'DomainController') {
                                 Get-RequiredFeature -Name web-mgmt-console -OSType $OSType.Value -Service "IIS"
                                 Get-RequiredFeature -Name Web-Scripting-Tools -OSType $OSType.Value -Service "IIS"
-                            } else {
+                            }
+                            else {
                                 Get-RequiredFeature -Name IIS-WebServerRole -OSType $OSType.Value -Service "IIS"
                                 Get-RequiredFeature -Name WebServerManagementTools -OSType $OSType.Value -Service "IIS"
                                 Get-RequiredFeature -Name IIS-ManagementScriptingTools -OSType $OSType.Value -Service "IIS"
                             }
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                } else {
+                }
+                else {
                     Write-PScriboMessage "No W3SVC service detected. Disabling IIS server section"
                 }
             }
@@ -270,7 +283,8 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                             Get-AbrWinSMBShare
                         }
                     }
-                } catch {
+                }
+                catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -293,13 +307,16 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # DHCP Server Per Scope Info
                                 Get-AbrWinDHCPv4PerScopeSetting
                             }
-                        } else {
+                        }
+                        else {
                             Get-RequiredFeature -Name RSAT-DHCP -OSType $OSType.Value -Service "DHCP Server"
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                } else {
+                }
+                else {
                     Write-PScriboMessage "No DHCPServer service detected. Disabling Dhcp server section"
                 }
             }
@@ -316,13 +333,16 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # DNS Zones Configuration
                                 Get-AbrWinDNSZone
                             }
-                        } else {
+                        }
+                        else {
                             Get-RequiredFeature -Name RSAT-DNS-Server -OSType $OSType.Value -Service "DNS Server"
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                } else {
+                }
+                else {
                     Write-PScriboMessage "No DNS Server service detected. Disabling DNS server section"
                 }
             }
@@ -356,13 +376,16 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 Get-AbrWinFOClusterSharedVolume
 
                             }
-                        } else {
+                        }
+                        else {
                             Get-RequiredFeature -Name RSAT-Clustering-PowerShell -OSType $OSType.Value -Service "FailOver Cluster"
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                } else {
+                }
+                else {
                     Write-PScriboMessage "No FailOver Cluster service detected. Disabling FailOver Cluster section"
                 }
             }
@@ -374,7 +397,8 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         if ($Options.SQLLogin) {
                             $SQLCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Options.SQLUserName, (ConvertTo-SecureString -Force $Options.SQLSecurePassword)
                             $script:SQLServer = Connect-DbaInstance -SqlInstance $System -TrustServerCertificate -SqlCredential $SQLCredential
-                        } else {
+                        }
+                        else {
                             $script:SQLServer = Connect-DbaInstance -SqlInstance $System -TrustServerCertificate -SqlCredential $Credential
                         }
                         if ($SQLServer) {
@@ -408,13 +432,16 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                             # Disconnect SQL Instance
                             Write-PScriboMessage "Disconnecting SQL Instance"
                             $SQLServer | Disconnect-DbaInstance | Out-Null
-                        } else {
+                        }
+                        else {
                             Write-PScriboMessage -IsWarning "Unable to connect to SQL Instance"
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                } else {
+                }
+                else {
                     Write-PScriboMessage "No SQL Server service detected. Disabling SQL Server section"
                 }
             }

--- a/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
@@ -107,34 +107,34 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
             #Local Users and Groups
             if ($InfoLevel.Account -ge 1) {
                 try {
-					# Get the AsBuiltReport.Microsoft.Windows Shared Util Functions path and file
-					$AsBuiltWinModuleFolder = (Get-InstalledModule -Name "AsBuiltReport.Microsoft.Windows" -AllVersions | Sort-Object Version -Descending | Select-Object -First 1).InstalledLocation
-					$SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
-					# Dot-source the script from the latest version
-					. $SharedFunctionPath 
-					# Read the Shared Util Function into a variable to pass through to a script block so that remote computers have this script available locally
-					$SharedFunctions = [System.IO.File]::ReadAllText($SharedFunctionPath)
-					# Get Local Users
-                    $LocalUsers = Invoke-Command -Session $TempPssSession { Get-LocalUser | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } }
-					
-					# Get Local Groups and their members
- 					$LocalGroups = Invoke-Command -Session $TempPssSession -ScriptBlock {
-						param ($ScriptContent)
-
-						# Create and dot-source the script block so the remote computer can use our shared functions
-						. ([scriptblock]::Create($ScriptContent))
-
-						$Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } } 
-						Write-Output $Result
-					} -ArgumentList $SharedFunctions	
-					
-					# Get Local Administrators members
-					$LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
-					# Remove empty or null elements
-					$LocalAdmins = $LocalAdmins | Where-Object { $_ }
-					
-					Write-Host "Local Admins -----"
-					$LocalAdmins
+			# Get the AsBuiltReport.Microsoft.Windows Shared Util Functions path and file
+			$AsBuiltWinModuleFolder = (Get-InstalledModule -Name "AsBuiltReport.Microsoft.Windows" -AllVersions | Sort-Object Version -Descending | Select-Object -First 1).InstalledLocation
+			$SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
+			# Dot-source the script from the latest version
+			. $SharedFunctionPath 
+			# Read the Shared Util Function into a variable to pass through to a script block so that remote computers have this script available locally
+			$SharedFunctions = [System.IO.File]::ReadAllText($SharedFunctionPath)
+			# Get Local Users
+                    	$LocalUsers = Invoke-Command -Session $TempPssSession { Get-LocalUser | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } }
+			
+			# Get Local Groups and their members
+			$LocalGroups = Invoke-Command -Session $TempPssSession -ScriptBlock {
+				param ($ScriptContent)
+	
+				# Create and dot-source the script block so the remote computer can use our shared functions
+				. ([scriptblock]::Create($ScriptContent))
+	
+				$Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } } 
+				Write-Output $Result
+			} -ArgumentList $SharedFunctions	
+			
+			# Get Local Administrators members
+			$LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
+			# Remove empty or null elements
+			$LocalAdmins = $LocalAdmins | Where-Object { $_ }
+			
+			Write-Host "Local Admins -----"
+			$LocalAdmins
 
                     if ($LocalUsers -or $LocalGroups -or $LocalAdmins) {
                         Section -Style Heading2 'Local Users and Groups' {

--- a/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
@@ -107,9 +107,35 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
             #Local Users and Groups
             if ($InfoLevel.Account -ge 1) {
                 try {
+					# Get the AsBuiltReport.Microsoft.Windows Shared Util Functions path and file
+					$AsBuiltWinModuleFolder = (Get-InstalledModule -Name "AsBuiltReport.Microsoft.Windows" -AllVersions | Sort-Object Version -Descending | Select-Object -First 1).InstalledLocation
+					$SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
+					# Dot-source the script from the latest version
+					. $SharedFunctionPath 
+					# Read the Shared Util Function into a variable to pass through to a script block so that remote computers have this script available locally
+					$SharedFunctions = [System.IO.File]::ReadAllText($SharedFunctionPath)
+					# Get Local Users
                     $LocalUsers = Invoke-Command -Session $TempPssSession { Get-LocalUser | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } }
-                    $LocalGroups = Invoke-Command -Session $TempPssSession { Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMember -Group $_.Name).Name } } }
-                    $LocalAdmins = Invoke-Command -Session $TempPssSession { Get-LocalGroupMember -Name 'Administrators' -ErrorAction SilentlyContinue }
+					
+					# Get Local Groups and their members
+ 					$LocalGroups = Invoke-Command -Session $TempPssSession -ScriptBlock {
+						param ($ScriptContent)
+
+						# Create and dot-source the script block so the remote computer can use our shared functions
+						. ([scriptblock]::Create($ScriptContent))
+
+						$Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } } 
+						Write-Output $Result
+					} -ArgumentList $SharedFunctions	
+					
+					# Get Local Administrators members
+					$LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
+					# Remove empty or null elements
+					$LocalAdmins = $LocalAdmins | Where-Object { $_ }
+					
+					Write-Host "Local Admins -----"
+					$LocalAdmins
+
                     if ($LocalUsers -or $LocalGroups -or $LocalAdmins) {
                         Section -Style Heading2 'Local Users and Groups' {
                             Paragraph 'The following section details local configured users and groups'

--- a/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
@@ -135,9 +135,6 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                     $LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
                     # Remove empty or null elements
                     $LocalAdmins = $LocalAdmins | Where-Object { $_ }
-					
-                    Write-Host "Local Admins -----"
-                    $LocalAdmins
 
                     if ($LocalUsers -or $LocalGroups -or $LocalAdmins) {
                         Section -Style Heading2 'Local Users and Groups' {

--- a/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Microsoft.Windows.ps1
@@ -5,7 +5,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
     .DESCRIPTION
         Documents the configuration of Microsoft Windows Server in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.5.3
+        Version:        0.5.5
         Author:         Andrew Ramsay
         Editor:         Jonathan Colon
         Twitter:        @asbuiltreport
@@ -38,8 +38,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                 Write-PScriboMessage -Plugin "Module" -IsWarning "Run 'Update-Module -Name AsBuiltReport.Microsoft.Windows -Force' to install the latest version."
             }
         }
-    }
-    Catch {
+    } Catch {
         Write-PScriboMessage -IsWarning $_.Exception.Message
     }
 
@@ -67,8 +66,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
             try {
                 $script:TempPssSession = New-PSSession $System -Credential $Credential -Authentication Negotiate -ErrorAction stop
                 $script:TempCimSession = New-CimSession $System -Credential $Credential -Authentication Negotiate -ErrorAction stop
-            }
-            catch {
+            } catch {
                 Write-PScriboMessage -IsWarning  "Unable to connect to $($System)"
                 throw
             }
@@ -102,8 +100,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         # Host Service Status
                         Get-AbrWinOSService
                     }
-                }
-                catch {
+                } catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -114,23 +111,23 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                     $AsBuiltWinModuleFolder = (Get-Module -ListAvailable -Name "AsBuiltReport.Microsoft.Windows" | Sort-Object Version -Descending | Select-Object -First 1).Path | Split-Path
                     $SharedFunctionPath = Join-Path -Path $AsBuiltWinModuleFolder -ChildPath "Src\Private\SharedUtilsFunctions.ps1"
                     # Dot-source the script from the latest version
-                    . $SharedFunctionPath 
+                    . $SharedFunctionPath
                     # Read the Shared Util Function into a variable to pass through to a script block so that remote computers have this script available locally
                     $SharedFunctions = [System.IO.File]::ReadAllText($SharedFunctionPath)
                     # Get Local Users
                     $LocalUsers = Invoke-Command -Session $TempPssSession { Get-LocalUser | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } }
-					
+
                     # Get Local Groups and their members
                     $LocalGroups = Invoke-Command -Session $TempPssSession -ScriptBlock {
                         param ($ScriptContent)
-			
+
                         # Create and dot-source the script block so the remote computer can use our shared functions
                         . ([scriptblock]::Create($ScriptContent))
-			
-                        $Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } } 
+
+                        $Result = Get-LocalGroup | Where-Object { $_.PrincipalSource -ne "ActiveDirectory" } | ForEach-Object { [PSCustomObject]@{ GroupName = $_.Name; Description = $_.Description; Members = (Get-LocalGroupMembership -Group $_.Name -Depth 1).Name } }
                         Write-Output $Result
-                    } -ArgumentList $SharedFunctions	
-					
+                    } -ArgumentList $SharedFunctions
+
                     # Get Local Administrators members
                     $LocalAdmins = Get-LocalGroupMembership -Group 'Administrators' -Computer $System -Depth 1 -ErrorAction Continue
                     # Remove empty or null elements
@@ -146,10 +143,9 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                             Get-AbrWinLocalGroup
                             #Local Administrators
                             Get-AbrWinLocalAdmin
-                        }
+                            ScriptContent }
                     }
-                }
-                catch {
+                } catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -174,8 +170,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         #Host Network Adapter MTU
                         Get-AbrWinNetAdapterMTU
                     }
-                }
-                catch {
+                } catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -193,8 +188,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         #MPIO Setting
                         Get-AbrWinHostStorageMPIO
                     }
-                }
-                catch {
+                } catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -216,16 +210,13 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # Hyper-V VM Information
                                 Get-AbrWinHyperVHostVM
                             }
-                        }
-                        else {
+                        } else {
                             Get-RequiredFeature -Name Hyper-V-PowerShell -OSType $OSType.Value -Service "Hyper-V"
                         }
-                    }
-                    catch {
+                    } catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                }
-                else {
+                } else {
                     Write-PScriboMessage "No HyperV service detected. Disabling HyperV server section"
                 }
             }
@@ -244,24 +235,20 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # IIS Web Site
                                 Get-AbrWinIISWebSite
                             }
-                        }
-                        else {
+                        } else {
                             If ($OSType -eq 'Server' -or $OSType -eq 'DomainController') {
                                 Get-RequiredFeature -Name web-mgmt-console -OSType $OSType.Value -Service "IIS"
                                 Get-RequiredFeature -Name Web-Scripting-Tools -OSType $OSType.Value -Service "IIS"
-                            }
-                            else {
+                            } else {
                                 Get-RequiredFeature -Name IIS-WebServerRole -OSType $OSType.Value -Service "IIS"
                                 Get-RequiredFeature -Name WebServerManagementTools -OSType $OSType.Value -Service "IIS"
                                 Get-RequiredFeature -Name IIS-ManagementScriptingTools -OSType $OSType.Value -Service "IIS"
                             }
                         }
-                    }
-                    catch {
+                    } catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                }
-                else {
+                } else {
                     Write-PScriboMessage "No W3SVC service detected. Disabling IIS server section"
                 }
             }
@@ -280,8 +267,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                             Get-AbrWinSMBShare
                         }
                     }
-                }
-                catch {
+                } catch {
                     Write-PScriboMessage -IsWarning $_.Exception.Message
                 }
             }
@@ -304,16 +290,13 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # DHCP Server Per Scope Info
                                 Get-AbrWinDHCPv4PerScopeSetting
                             }
-                        }
-                        else {
+                        } else {
                             Get-RequiredFeature -Name RSAT-DHCP -OSType $OSType.Value -Service "DHCP Server"
                         }
-                    }
-                    catch {
+                    } catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                }
-                else {
+                } else {
                     Write-PScriboMessage "No DHCPServer service detected. Disabling Dhcp server section"
                 }
             }
@@ -330,16 +313,13 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 # DNS Zones Configuration
                                 Get-AbrWinDNSZone
                             }
-                        }
-                        else {
+                        } else {
                             Get-RequiredFeature -Name RSAT-DNS-Server -OSType $OSType.Value -Service "DNS Server"
                         }
-                    }
-                    catch {
+                    } catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                }
-                else {
+                } else {
                     Write-PScriboMessage "No DNS Server service detected. Disabling DNS server section"
                 }
             }
@@ -373,16 +353,13 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                                 Get-AbrWinFOClusterSharedVolume
 
                             }
-                        }
-                        else {
+                        } else {
                             Get-RequiredFeature -Name RSAT-Clustering-PowerShell -OSType $OSType.Value -Service "FailOver Cluster"
                         }
-                    }
-                    catch {
+                    } catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                }
-                else {
+                } else {
                     Write-PScriboMessage "No FailOver Cluster service detected. Disabling FailOver Cluster section"
                 }
             }
@@ -394,8 +371,7 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                         if ($Options.SQLLogin) {
                             $SQLCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Options.SQLUserName, (ConvertTo-SecureString -Force $Options.SQLSecurePassword)
                             $script:SQLServer = Connect-DbaInstance -SqlInstance $System -TrustServerCertificate -SqlCredential $SQLCredential
-                        }
-                        else {
+                        } else {
                             $script:SQLServer = Connect-DbaInstance -SqlInstance $System -TrustServerCertificate -SqlCredential $Credential
                         }
                         if ($SQLServer) {
@@ -429,16 +405,13 @@ function Invoke-AsBuiltReport.Microsoft.Windows {
                             # Disconnect SQL Instance
                             Write-PScriboMessage "Disconnecting SQL Instance"
                             $SQLServer | Disconnect-DbaInstance | Out-Null
-                        }
-                        else {
+                        } else {
                             Write-PScriboMessage -IsWarning "Unable to connect to SQL Instance"
                         }
-                    }
-                    catch {
+                    } catch {
                         Write-PScriboMessage -IsWarning $_.Exception.Message
                     }
-                }
-                else {
+                } else {
                     Write-PScriboMessage "No SQL Server service detected. Disabling SQL Server section"
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed issue with getting local group members being blank if any member of that group contains an orphaned SID. Fix #31 

## Description
Added a function called Get-LocalGroupMembership to get local group members that does not have an issue with group members with an orphaned SID.
The original author of the Get-LocalGroupMembership function  is Boe Prox: [https://github.com/proxb/PowerShell_Scripts/blob/master/Get-LocalGroupMembership.ps1](url)
The function has been modified slightly so that the output is compatible with the native Get-LocalGroupMember (to prevent re-work)


## Related Issue
[https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.Windows/issues/31](url)

## Motivation and Context
Solves issue: [https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.Windows/issues/31](url)
Without this fix, if a member of any of your local groups SID could not be resolved, the output for that group membership would be blank.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested on Powershell 5.1 and Powershell 7.4.2
This has also been tested against the following Windows Operating Systems:
Windows Server 2008 R2
Windows Server 2016
Windows Server 2019
Windows Server 2022

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
